### PR TITLE
Add Jumbo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,28 @@
 
 **Slash Commands**
 - `/ping`
-- `/source id:`
-- `/release type:`
+- `/source` `id:`
+- `/download` `repository:`
 - `/user`
-  - `avatar target:`
-  - `banner target:`
+  - `avatar` `target:`
+  - `banner` `target:`
 - `/steps`
+- `/jumbo` `emote:`
 
 **Message Commands**
 - `Request Steps`
 
 **Scopes**
-- application.commands
-- bot
+- `application.commands`
+- `bot`
 
 **Bot Permissions**
-- Send Messages
-- Read Messages/View Channels
+- `Send Messages`
+- `View Channels`
+- `View Message History`
+- `Attach Files`
+
+[Permission calculator](https://discordapi.com/permissions.html#101376)
 
 ## Development
 - 100% Kotlin
@@ -70,7 +75,7 @@ If you choose to develop a feature or fix a bug it's highly recommended that you
 1. Build the JAR 
    - `./gradlew installDist`
 2. Run the JAR
-   - `java -jar ./app/build/install/app/bin/app <BOT_TOKEN> <IGNORE_ROLES>`
+   - `./app/build/install/app/bin/app <BOT_TOKEN> <IGNORE_ROLES>`
 
 ### Intellij IDEA
 1. Open Run/Debug Configuration `Run -> Edit Configurations...`

--- a/app/src/main/kotlin/me/ghostbear/kumaslash/KumaSlashApplication.kt
+++ b/app/src/main/kotlin/me/ghostbear/kumaslash/KumaSlashApplication.kt
@@ -24,6 +24,7 @@ import me.ghostbear.core.OnModalSubmitInteractionCreateEvent
 import me.ghostbear.core.SlashCommand
 import me.ghostbear.core.SlashCommandGroup
 import me.ghostbear.kumaslash.commands.download.DownloadCommand
+import me.ghostbear.kumaslash.commands.jumbo.JumboCommand
 import me.ghostbear.kumaslash.commands.ping.PingCommand
 import me.ghostbear.kumaslash.commands.source.SourceCommand
 import me.ghostbear.kumaslash.commands.steps.RequestStepsCommand
@@ -58,6 +59,7 @@ val commands = mutableListOf(
     SourceCommand(),
     StepsCommand(),
     RequestStepsCommand(),
+    JumboCommand(),
 )
 
 suspend fun main(args: Array<String>) {

--- a/app/src/main/kotlin/me/ghostbear/kumaslash/commands/jumbo/JumboCommand.kt
+++ b/app/src/main/kotlin/me/ghostbear/kumaslash/commands/jumbo/JumboCommand.kt
@@ -1,0 +1,55 @@
+package me.ghostbear.kumaslash.commands.jumbo
+
+import dev.kord.core.behavior.interaction.respondEphemeral
+import dev.kord.core.behavior.interaction.respondPublic
+import dev.kord.core.event.interaction.GuildChatInputCommandInteractionCreateEvent
+import dev.kord.rest.builder.interaction.OptionsBuilder
+import dev.kord.rest.builder.interaction.StringChoiceBuilder
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.utils.io.jvm.javaio.*
+import me.ghostbear.core.OnGuildChatInputCommandInteractionCreateEvent
+import me.ghostbear.core.SlashCommand
+import me.ghostbear.kumaslash.client
+
+class JumboCommand : SlashCommand(), OnGuildChatInputCommandInteractionCreateEvent {
+    override val name: String = "jumbo"
+    override val description: String = "Make emotes show their original size"
+    override val parameters: MutableList<OptionsBuilder> = mutableListOf(
+        StringChoiceBuilder("emote", "Emote").apply {
+            required = true
+        }
+    )
+
+    override fun onGuildChatInputCommandInteractionCreateEvent(): suspend GuildChatInputCommandInteractionCreateEvent.() -> Unit = on@{
+        val command = interaction.command
+        val emote = command.strings["emote"]!!
+        val emoteRegex = Regex("\\<(a)?\\:(.*)\\:(.*)\\>")
+
+        try {
+            if (emote.matches(emoteRegex)) {
+                val emoteValidator = emoteRegex.find(emote)!!
+                val (emoteType, emoteName, emoteId) = emoteValidator.destructured
+
+                val emoteFormat: String = if (emoteType == "a") {
+                    "gif"
+                } else {
+                    "png"
+                }
+
+                val imageUrl = "https://cdn.discordapp.com/emojis/${emoteId}.${emoteFormat}?v=1"
+                val inputStream = client.get(imageUrl).bodyAsChannel().toInputStream()
+
+                interaction.respondPublic {
+                    this.addFile("${emoteName}.${emoteFormat}", inputStream)
+                }
+            } else {
+                interaction.respondEphemeral {
+                    content = "Please try again with a single valid emote."
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}


### PR DESCRIPTION
Sends emoji as their original size as an attachment

Uses: `/jumbo` `emote:`
Probably requires:`Attach Files`

![image](https://user-images.githubusercontent.com/10836780/167708419-536a9d6f-5e56-4c20-a5c8-f7b16496b348.png)
