### PR TITLE
Fix template comments

### DIFF
--- a/app/src/main/kotlin/me/ghostbear/kumaslash/commands/github/GitHubApi.kt
+++ b/app/src/main/kotlin/me/ghostbear/kumaslash/commands/github/GitHubApi.kt
@@ -78,6 +78,7 @@ val GitHubResponse.descriptionCleaned: String
 
         val cleanedBody = body
             .substringBefore("### Acknowledgements")
+            .replace("(?:<!--)(.*?)(?:-->)".toRegex(RegexOption.DOT_MATCHES_ALL), "")
             .replace("^((?:#{3})\\s(?:.*))(\\n\\n)".toRegex(RegexOption.MULTILINE), "$1\n")
             .replace("^(?:#{3})\\s(.*)\$".toRegex(RegexOption.MULTILINE), "**$1**")
 


### PR DESCRIPTION
Fixes so that when lazy people (such as @ivaniskandar and @AntsyLich and more) don't fill out any information at all for their PRs, this will just ignore the template comment:

![image](https://user-images.githubusercontent.com/10836780/177800800-72af5e65-4d21-4a58-aa77-d0dbbf69b80c.png)
