### PR TITLE
Match user mod actions more closely

### DIFF
--- a/app/src/main/kotlin/me/ghostbear/kumaslash/automation/TimoutReasonAutomation.kt
+++ b/app/src/main/kotlin/me/ghostbear/kumaslash/automation/TimoutReasonAutomation.kt
@@ -56,16 +56,6 @@ suspend fun Kord.timeoutReasonAutomation() {
             } else {
                 null
             }
-            try {
-                member
-                    .getDmChannel()
-                    .createMessage {
-                        content =
-                            "You've been timed out until <t:$epoch:f> in Tachiyomi with the following reason:\n> $reason"
-                    }
-            } catch (e: Exception) {
-                kordLogger.info { "Wasn't able to send timeout reason to user. Most likely due to them not allowing DMs from server members" }
-            }
 
             val timeoutTime = (epoch - (entry?.id?.timestamp?.epochSeconds ?: 0)).toDuration(DurationUnit.SECONDS)
             val timeoutString = when {
@@ -77,6 +67,36 @@ suspend fun Kord.timeoutReasonAutomation() {
                 timeoutTime.inWholeSeconds >= 5.minutes.inWholeSeconds -> "5 minutes"
                 timeoutTime.inWholeSeconds >= 1.minutes.inWholeSeconds -> "1 minutes"
                 else -> timeoutTime.toString()
+            }
+
+            try {
+                member
+                    .getDmChannel()
+                    .createMessage {
+                        embed {
+                            title = "You were timed out"
+                            color = Color(47, 49, 54)
+                            field {
+                                name = "Reason"
+                                value = reason
+                            }
+                            field {
+                                name = "Duration"
+                                value = "$timeoutString (until <t:${epoch}:f>)"
+                            }
+                            field {
+                                name = "Moderator"
+                                value = moderator?.mention ?: "Unknown"
+                            }
+                            author {
+                                name = "Tachiyomi"
+                                icon = "https://cdn.discordapp.com/icons/349436576037732353/a_989e89146244387118ab43b03776a90b.webp"
+                                url = "https://discord.gg/tachiyomi"
+                            }
+                        }
+                    }
+            } catch (e: Exception) {
+                kordLogger.info { "Wasn't able to send timeout reason to user. Most likely due to them not allowing DMs from server members" }
             }
 
             try {
@@ -99,10 +119,10 @@ suspend fun Kord.timeoutReasonAutomation() {
                             embed {
                                 title = "timeout"
                                 description = """
-                                Offender: ${member.mention}
-                                Reason: $reason
-                                Duration: $timeoutString (until <t:${epoch}:f>)
-                                Moderator: ${moderator?.mention}
+                                **Offender:** ${member.mention}
+                                **Duration:** $timeoutString (until <t:${epoch}:f>)
+                                **Reason:** $reason
+                                **Moderator:** ${moderator?.mention}
                             """.trimIndent()
                                 footer {
                                     text = "Offender ID: ${member.id.value}"


### PR DESCRIPTION
This PR aims to be more consistent with other messages the User gets DM'd for, as well as general consistency (and improvement) with how it looks in our own modlog channel.

### Match Carl-bot closer with built-in for Modlogs
| New | Old | Reference |
| --- | --- | --------- |
| ![image](https://user-images.githubusercontent.com/10836780/190871523-296066cd-4168-4c6e-93aa-1b0528b2fb72.png) | ![image](https://user-images.githubusercontent.com/10836780/190871570-3681af36-6278-4258-878a-99dda5ad237a.png) | ![image](https://user-images.githubusercontent.com/10836780/190871637-b737c77a-3b35-4eca-b8ab-8225fd3f288c.png) |

### Match custom mod actions logs to DMs
| New | Old | Reference |
| --- | --- | --------- |
| ![image](https://user-images.githubusercontent.com/10836780/190871526-33c62e56-325f-4733-876b-18d4659868fe.png) | ![image](https://user-images.githubusercontent.com/10836780/190871579-692167fa-16f8-40b7-9f71-a75b044e2646.png) | ![image](https://user-images.githubusercontent.com/10836780/190871616-dd9a5f69-ce81-4361-ad42-3431f9efe471.png) |